### PR TITLE
Fix preview port handling for Playwright E2E

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ downloads/
 eggs/
 .eggs/
 lib/
+!ai-gm/src/app/lib/
 lib64/
 parts/
 sdist/

--- a/ai-gm/playwright.config.ts
+++ b/ai-gm/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    headless: true,
+  },
+  webServer: {
+    command: 'node scripts/preview.mjs',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/ai-gm/scripts/preview.mjs
+++ b/ai-gm/scripts/preview.mjs
@@ -1,0 +1,38 @@
+import { preview } from 'vite';
+
+const port = Number.parseInt(process.env.PORT ?? '4173', 10);
+const host = process.env.HOST ?? '127.0.0.1';
+
+async function start() {
+  try {
+    const server = await preview({
+      preview: {
+        host,
+        port,
+        strictPort: true,
+      },
+    });
+
+    server.printUrls();
+
+    const close = async () => {
+      await server.close();
+    };
+
+    for (const signal of ['SIGINT', 'SIGTERM']) {
+      process.once(signal, async () => {
+        await close();
+        process.exit(0);
+      });
+    }
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'EADDRINUSE') {
+      console.error(`Port ${port} is already in use. Please stop the existing process or choose a different port.`);
+    } else {
+      console.error('Failed to start preview server:', error);
+    }
+    process.exit(1);
+  }
+}
+
+start();

--- a/ai-gm/src/app/lib/pdf/extract.ts
+++ b/ai-gm/src/app/lib/pdf/extract.ts
@@ -1,0 +1,50 @@
+import { getDocument, GlobalWorkerOptions } from 'pdfjs-dist';
+// @ts-ignore bundler handles ?url imports
+import workerSrc from 'pdfjs-dist/build/pdf.worker.min.mjs?url';
+
+const globalDoc = typeof globalThis !== 'undefined' ? (globalThis as unknown as { document?: Document }) : undefined;
+
+if (globalDoc?.document) {
+  GlobalWorkerOptions.workerSrc = workerSrc;
+}
+
+export interface PdfTextPage {
+  index: number;
+  text: string;
+}
+
+export const normalizePdfText = (text: string) =>
+  text
+    .replace(/\s+/g, ' ')
+    .replace(/\s([,.!?:;])/g, '$1')
+    .trim();
+
+export const extractTextFromPdf = async (file: File): Promise<PdfTextPage[]> => {
+  const data = await file.arrayBuffer();
+  const task = getDocument({ data });
+  const pdf = await task.promise;
+  const pages: PdfTextPage[] = [];
+
+  for (let i = 1; i <= pdf.numPages; i += 1) {
+    const page = await pdf.getPage(i);
+    const content = await page.getTextContent();
+    const text = content.items
+      .map((item) => ('str' in item ? item.str : ''))
+      .join(' ');
+    pages.push({ index: i, text: normalizePdfText(text) });
+  }
+
+  return pages;
+};
+
+type FileCollection = ArrayLike<File> | Iterable<File>;
+
+export const extractAllText = async (files: FileCollection): Promise<string> => {
+  const list = Array.from(files as ArrayLike<File>);
+  const pages = await Promise.all(list.map((file) => extractTextFromPdf(file)));
+  return pages
+    .flat()
+    .sort((a, b) => a.index - b.index)
+    .map((page) => page.text)
+    .join('\n\n');
+};


### PR DESCRIPTION
## Summary
- ensure the ai-gm library directory is tracked by overriding the root gitignore
- add a strict-port Vite preview launcher and point Playwright at it to keep the preview on 4173
- adjust the pdf worker import shim to use ts-ignore so the build succeeds

## Testing
- pnpm build
- pnpm e2e *(fails: browsers not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fe74828488329a49e2c2025702d7d)