### PR TITLE
Claude/address pr review 5 

### DIFF
--- a/ai-gm/src/app/components/ChatPanel.tsx
+++ b/ai-gm/src/app/components/ChatPanel.tsx
@@ -87,10 +87,26 @@ export default function ChatPanel() {
         updateJournal((j) => {
           let updatedJournal = appendSessionLogEntry(j, summary)
 
-          // Add any newly created characters to the party
+          // Add or update newly created characters in the party
           if (response.createdCharacters && response.createdCharacters.length > 0) {
             const currentParty = updatedJournal.frontMatter.party
-            const newParty = [...currentParty, ...response.createdCharacters]
+            const newParty = [...currentParty]
+
+            // Merge characters: update existing or add new
+            for (const character of response.createdCharacters) {
+              const existingIndex = newParty.findIndex(
+                (c) => c.name.toLowerCase() === character.name.toLowerCase()
+              )
+
+              if (existingIndex >= 0) {
+                // Update existing character
+                newParty[existingIndex] = character
+              } else {
+                // Add new character
+                newParty.push(character)
+              }
+            }
+
             updatedJournal = updateParty(updatedJournal, newParty)
           }
 

--- a/ai-gm/tests/journal.serialize.spec.ts
+++ b/ai-gm/tests/journal.serialize.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { serializeJournal, appendSessionLogEntry } from '../src/lib/journal/serialize'
+import { serializeJournal, appendSessionLogEntry, updateParty } from '../src/lib/journal/serialize'
 import { parseJournal, createDefaultJournal } from '../src/lib/journal/parse'
 
 describe('serializeJournal', () => {
@@ -82,6 +82,48 @@ describe('appendSessionLogEntry', () => {
     await new Promise((resolve) => setTimeout(resolve, 10))
 
     const updated = appendSessionLogEntry(journal, 'Test entry')
+    expect(updated.frontMatter.updated_at).not.toBe(originalTime)
+  })
+})
+
+describe('updateParty', () => {
+  it('should update party array', () => {
+    const journal = createDefaultJournal('BX', {
+      ability_scores_4d6L: false,
+      level1_max_hp: false,
+    })
+
+    const newParty = [
+      {
+        name: 'Slick',
+        class: 'Thief',
+        level: 1,
+        hp: 4,
+        max_hp: 4,
+        abilities: { str: 9, int: 13, wis: 10, dex: 16, con: 12, cha: 14 },
+        inventory: ['Lockpicks', 'Dagger'],
+        ac: 7,
+        xp: 0,
+      },
+    ]
+
+    const updated = updateParty(journal, newParty)
+    expect(updated.frontMatter.party).toHaveLength(1)
+    expect(updated.frontMatter.party[0].name).toBe('Slick')
+  })
+
+  it('should update timestamp when party changes', async () => {
+    const journal = createDefaultJournal('BX', {
+      ability_scores_4d6L: false,
+      level1_max_hp: false,
+    })
+
+    const originalTime = journal.frontMatter.updated_at
+
+    // Small delay to ensure different timestamp
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    const updated = updateParty(journal, [])
     expect(updated.frontMatter.updated_at).not.toBe(originalTime)
   })
 })


### PR DESCRIPTION
Resolves the critical bug where multiple instances of the same character were added to the Party instead of updating existing characters.

Changes:
- Modified ChatPanel.tsx to check for existing characters by name (case-insensitive)
- When a character is created, update the existing character if found, otherwise add new
- Added tests for updateParty function in journal.serialize.spec.ts

Before: Characters were blindly appended to party array, causing duplicates
After: Characters are merged intelligently - existing characters are updated, new ones are added

Impact: Fixes PR #5 review comment - only one instance of each character exists in the Party