### PR TITLE
Update README dice audit description

### DIFF
--- a/ai-gm/README.md
+++ b/ai-gm/README.md
@@ -106,7 +106,7 @@ src/
 **Tool-Driven Dice**
 - All dice rolls use the `roll_dice` function tool
 - GM never simulates or makes up results
-- Each response includes a "Dice audit" section
+- Dice results appear in the dedicated Dice audit panel, separate from the narrative transcript
 
 **Rules Primacy**
 - GM only uses uploaded rules and module


### PR DESCRIPTION
## Summary
- clarify that dice results now appear in the dedicated Dice audit panel instead of inline with responses

## Testing
- Not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910e725a95c83298b299d52f3d1e3b9)