### PR TITLE
fix: AI GM now reads journal file on load

### DIFF
--- a/ai-gm/src/app/components/ChatPanel.tsx
+++ b/ai-gm/src/app/components/ChatPanel.tsx
@@ -72,6 +72,7 @@ export default function ChatPanel() {
         messages: apiMessages,
         rulesContext: rulesPdf.fullText,
         moduleContext: modulePdf.fullText,
+        journal,
         model: settings.model,
         settings,
       })


### PR DESCRIPTION
When a user specifies a journal file at session start, the AI GM now automatically reads and processes it to understand the current adventure state. This allows the journal file to function as a proper saved game.

Changes:
- Modified GMRequest interface to accept optional journal parameter
- Updated buildSystemInstructions() to include journal context in system prompt
- Journal context includes: party info, session log, character details, inventory, and house rules
- ChatPanel now passes journal data to getGMResponse()

The AI GM will now have full context of:
- Current party members with their stats and inventory
- Previous session events (last 10 entries)
- Character descriptions and party inventory
- Custom house rules from the journal

Fixes #22