### PR TITLE
fix: use max_completion_tokens for GPT-5 models (issue #25) 

### DIFF
--- a/ai-gm/src/app/components/SettingsDrawer.tsx
+++ b/ai-gm/src/app/components/SettingsDrawer.tsx
@@ -4,6 +4,9 @@ import { formatLabel } from '@/lib/ui/formatting'
 export default function SettingsDrawer() {
   const { isSettingsOpen, setSettingsOpen, settings, updateSettings } = useAppStore()
 
+  // GPT-5 models don't support temperature or max_tokens parameters
+  const isGPT5Model = settings.model.toLowerCase().includes('gpt-5')
+
   if (!isSettingsOpen) return null
 
   return (
@@ -76,10 +79,13 @@ export default function SettingsDrawer() {
                     const value = parseFloat(e.target.value)
                     updateSettings({ temperature: isNaN(value) ? 1 : value })
                   }}
-                  className="input w-full"
+                  disabled={isGPT5Model}
+                  className="input w-full disabled:cursor-not-allowed disabled:opacity-50"
                 />
                 <p className="mt-1 text-xs text-text-muted">
-                  Higher values make output more random, lower values more focused
+                  {isGPT5Model
+                    ? 'Not supported by GPT-5 models'
+                    : 'Higher values make output more random, lower values more focused'}
                 </p>
               </div>
               <div>
@@ -98,10 +104,13 @@ export default function SettingsDrawer() {
                     })
                   }
                   placeholder="Default (model-specific)"
-                  className="input w-full"
+                  disabled={isGPT5Model}
+                  className="input w-full disabled:cursor-not-allowed disabled:opacity-50"
                 />
                 <p className="mt-1 text-xs text-text-muted">
-                  Limits the length of GM responses
+                  {isGPT5Model
+                    ? 'Not supported by GPT-5 models (uses max_completion_tokens instead)'
+                    : 'Limits the length of GM responses'}
                 </p>
               </div>
             </div>

--- a/ai-gm/src/lib/openai/orchestration.ts
+++ b/ai-gm/src/lib/openai/orchestration.ts
@@ -192,7 +192,8 @@ export async function getGMResponse(request: GMRequest): Promise<GMResponse> {
     iterations++
 
     // Determine which token parameter to use based on model
-    // GPT-5 models require max_completion_tokens, GPT-4 models use max_tokens
+    // GPT-5 models require max_completion_tokens and don't support temperature
+    // GPT-4 models use max_tokens and support temperature
     const isGPT5Model = model.toLowerCase().includes('gpt-5')
     const tokenParam = isGPT5Model ? 'max_completion_tokens' : 'max_tokens'
 
@@ -202,7 +203,8 @@ export async function getGMResponse(request: GMRequest): Promise<GMResponse> {
       messages: currentMessages,
       tools: tools as OpenAI.Chat.Completions.ChatCompletionTool[],
       parallel_tool_calls: false, // Force sequential tool calls for determinism
-      ...(settings?.temperature !== undefined && { temperature: settings.temperature }),
+      // GPT-5 models don't support temperature parameter
+      ...(!isGPT5Model && settings?.temperature !== undefined && { temperature: settings.temperature }),
       ...(settings?.max_tokens !== undefined && { [tokenParam]: settings.max_tokens }),
     })
 


### PR DESCRIPTION
## `max_completion_tokens`

GPT-5 models require the `max_completion_tokens` parameter instead of
`max_tokens`. This change adds model detection to use the correct
parameter based on the model type:

- GPT-5 models: use max_completion_tokens
- GPT-4 models: use max_tokens (existing behavior)

This fixes the "Unsupported parameter: 'max_tokens' is not supported"
error that occurred when using GPT-5 models.

## `temperature`

GPT-5 models don't support the `temperature` parameter in addition to
requiring `max_completion_tokens` instead of max_tokens.

Changes:

- `orchestration.ts`: Exclude temperature parameter for GPT-5 models
- `SettingsDrawer.tsx`: Disable temperature and max_tokens inputs when
  GPT-5 model is selected, with helpful explanatory text

Fixes #25 