### PR TITLE
Add README for oracle package

### DIFF
--- a/oracle-cli/oracle/README.md
+++ b/oracle-cli/oracle/README.md
@@ -10,18 +10,18 @@ This package provides the stateless oracle logic that powers the Oracle CLI, exp
 - `oracle.core.chaos.roll_chaos`: Rolls chaos dice and reports how the pool escalates or resets.
 - `oracle.util.OracleRNG`: Wraps `random.Random` to deliver deterministic dice rolls across the oracles.
 
-## Installing
+## Install
 
-Install the package locally while in the repository root:
+Install the package locally while in the repository root using `uv`:
 
 ```bash
-pip install .
+uv tool install .
 ```
 
 To develop against the project without installing globally, use editable mode:
 
 ```bash
-pip install -e .
+uv tool install --editable .
 ```
 
 ## Using the oracles programmatically


### PR DESCRIPTION
## Summary
- add README describing the oracle package purpose and key components
- provide installation guidance and programmatic usage examples
- document where oracle data tables are stored and how they are loaded

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929d71adc00832988eb20dd53bae79b)